### PR TITLE
track failed rollups and unmerged closed PRs

### DIFF
--- a/data/rust-lang/rust/pr-merged.csv
+++ b/data/rust-lang/rust/pr-merged.csv
@@ -1,4 +1,4 @@
-"is:merged merged:{{"">1""|relative_date}} {{param}}",label:merged-by-bors|merged by bors,-label:merged-by-bors|rolled up
+"is:closed closed:{{"">1""|relative_date}} {{param}}",is:merged label:merged-by-bors|merged by bors,is:merged -label:merged-by-bors|rolled up,is:unmerged label:rollup|failed rollup,is:unmerged -label:rollup|not merged
 2023-01-29,8,17
 2023-01-28,7,17
 2023-01-27,7,37

--- a/index.md
+++ b/index.md
@@ -5,6 +5,6 @@ graphs:
   pr-status: Pull requests status
   pr-activity: Last activity on pull requests
   pr-age: Pull requests creation dates
-  pr-merged: Pull requests merged
+  pr-merged: Pull requests closed
 layout: graphs
 ---


### PR DESCRIPTION
You can check that these searches return the same results using the following searches:

- [`is:pr is:closed closed:2023-01-29 is:merged label:merged-by-bors`](https://github.com/rust-lang/rust/pulls?q=is%3Apr+is%3Aclosed+closed%3A2023-01-29+is%3Amerged+label%3Amerged-by-bors+)
- [`is:pr is:merged merged:2023-01-29 label:merged-by-bors`](https://github.com/rust-lang/rust/pulls?q=is%3Apr+is%3Amerged+merged%3A2023-01-29+label%3Amerged-by-bors+)
- [`is:pr is:closed closed:2023-01-29 is:merged -label:merged-by-bors`](https://github.com/rust-lang/rust/pulls?q=is%3Apr+is%3Aclosed+closed%3A2023-01-29+is%3Amerged+-label%3Amerged-by-bors+)
- [`is:pr is:merged merged:2023-01-29 -label:merged-by-bors`](https://github.com/rust-lang/rust/pulls?q=is%3Apr+is%3Amerged+merged%3A2023-01-29+-label%3Amerged-by-bors+)

Change the date around and you'll always get the same results.